### PR TITLE
Fix minor issues that causes errors when uploading multiple data records

### DIFF
--- a/import_ble.sh
+++ b/import_ble.sh
@@ -29,7 +29,7 @@ else read_all=`python3 -B $path/scanner_ble.py | awk 'END{print}'`
 fi
 
 # Calculate data and export to Garmin Connect, logging, handling errors, backup file
-if [ -f $path/*.tlog ] ; then
+if compgen -D "$path/*.tlog" ; then
 	python3 -B $path/export_garmin.py > $path/temp.log 2>&1
 	move=`awk -F ": " '/Processed file:/{print $2}' $path/temp.log`
 	if grep -q 'Error\|panic\|denied\|There\|Exec' $path/temp.log ; then

--- a/import_ble.sh
+++ b/import_ble.sh
@@ -16,7 +16,7 @@ fi
 if [ -z `hcitool dev | awk 'NR>1 {print $2}'` ] ; then
 	echo '* No BLE device detected'
 else read_all=`python3 -B $path/scanner_ble.py | awk 'END{print}'`
-	 read_unixtime=`echo $read_all | awk -F "\"*;\"*" 'END{print $3}'`
+	 read_unixtime=`echo $read_all | awk -F "\"*;\"*" 'END{print $4}'`
 	if [ -z $read_unixtime ] ; then
 		echo '* No BLE data from scale or incomplete'
 	elif grep -q $read_unixtime $path/backup.csv ; then


### PR DESCRIPTION
When checking for existing data records, the script looks at the wrong data field from the output of the scanner program. This causes the data to uploaded every time, until the scale stops broadcasting the data.

Also fix the issue where we check for a single tlog file.
If there are multiple files, the old check would fail, and no data would be uploaded.