### PR TITLE
Fix BodyType rating

### DIFF
--- a/Xiaomi_Scale_Body_Metrics.py
+++ b/Xiaomi_Scale_Body_Metrics.py
@@ -208,11 +208,11 @@ class bodyMetrics:
             factor = 1
 
         if self.getMuscleMass() > self.scales.getMuscleMassScale()[1]:
-            return 2 + (factor * 3)
+            return 3 + (factor * 3)
         elif self.getMuscleMass() < self.scales.getMuscleMassScale()[0]:
-            return (factor * 3)
-        else:
             return 1 + (factor * 3)
+        else:
+            return 2 + (factor * 3)
 
     # Get Metabolic Age
     def getMetabolicAge(self):


### PR DESCRIPTION
Fix for BodyType rating, I believe original calculation is zero based, but Garmin expects values from 1 to 9 and therefore it may be shifted for certain combinations.